### PR TITLE
Convert Index to struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "index_list"
-version = "0.1.0"
+version = "0.2.0"
 description = "A doubly linked list implemented in Rust using vector indexes"
 authors = ["Stefan Lindblad <stefan.lindblad@linux.com>"]
 edition = "2018"

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,7 +1,7 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use std::collections::vec_deque::VecDeque;
 use std::collections::LinkedList;
-use indexlist::*;
+use index_list::*;
 
 fn indexlist_head(n: u32) {
     let mut list = IndexList::<u32>::new();
@@ -42,7 +42,7 @@ fn indexlist_allover(n: u32) {
     });
     (0..n as usize).for_each(|i| {
         let val = 0;
-        let ndx = list.insert_before(i, val);
+        let ndx = list.insert_before(Index::from(i), val);
         let got = list.remove_index(ndx).unwrap();
         assert_eq!(got, val);
     })

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -43,7 +43,7 @@ fn indexlist_allover(n: u32) {
     (0..n as usize).for_each(|i| {
         let val = 0;
         let ndx = list.insert_before(Index::from(i), val);
-        let got = list.remove_index(ndx).unwrap();
+        let got = list.remove(ndx).unwrap();
         assert_eq!(got, val);
     })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,12 +269,12 @@ impl<T> IndexList<T> {
     pub fn insert_first(&mut self, elem: T) -> Index {
         let this = self.new_node(Some(elem));
         self.linkin_first(this);
-        Index::from(this)
+        this
     }
     pub fn insert_last(&mut self, elem: T) -> Index {
         let this = self.new_node(Some(elem));
         self.linkin_last(this);
-        Index::from(this)
+        this
     }
     pub fn insert_before(&mut self, index: Index, elem: T) -> Index {
         if index.is_none() {
@@ -329,7 +329,7 @@ impl<T> IndexList<T> {
         removed.iter().for_each(|&i| {
             self.linkout_free(Index::from(i));
         });
-        if removed.len() > 0 {
+        if !removed.is_empty() {
             let left = self.capacity() - removed.len();
             self.nodes.truncate(left);
             self.elems.truncate(left);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@ impl Index {
     fn new() -> Index {
         Index { 0: None }
     }
-    #[allow(dead_code)]
     #[inline]
     pub fn is_some(&self) -> bool {
         self.0.is_some()
@@ -22,14 +21,6 @@ impl Index {
     #[inline]
     fn get(&self) -> Option<usize> {
         Some(self.0?.get() as usize - 1)
-    }
-    #[inline]
-    pub fn get_raw(&self) -> u32 {
-        if let Some(n) = self.0 {
-            n.get()
-        } else {
-            0
-        }
     }
     #[inline]
     fn set(mut self, index: Option<usize>) -> Self {
@@ -119,31 +110,31 @@ struct IndexEnds {
 
 impl IndexEnds {
     #[inline]
-    pub fn new() -> Self {
+    fn new() -> Self {
         IndexEnds { head: Index::new(), tail: Index::new() }
     }
     #[inline]
-    pub fn clear(&mut self) {
+    fn clear(&mut self) {
         self.new_both(Index::new());
     }
     #[inline]
-    pub fn is_empty(&self) -> bool {
+    fn is_empty(&self) -> bool {
         self.head.is_none()
     }
     #[inline]
-    pub fn new_head(&mut self, head: Index) -> Index {
+    fn new_head(&mut self, head: Index) -> Index {
         let old_head = self.head;
         self.head = head;
         old_head
     }
     #[inline]
-    pub fn new_tail(&mut self, tail: Index) -> Index {
+    fn new_tail(&mut self, tail: Index) -> Index {
         let old_tail = self.tail;
         self.tail = tail;
         old_tail
     }
     #[inline]
-    pub fn new_both(&mut self, both: Index) {
+    fn new_both(&mut self, both: Index) {
         self.head = both;
         self.tail = both;
     }
@@ -237,27 +228,27 @@ impl<T> IndexList<T> {
     }
     #[inline]
     pub fn get_first(&self) -> Option<&T> {
-        self.get_index(self.first_index())
+        self.get(self.first_index())
     }
     #[inline]
     pub fn get_last(&self) -> Option<&T> {
-        self.get_index(self.last_index())
+        self.get(self.last_index())
     }
     #[inline]
-    pub fn get_index(&self, index: Index) -> Option<&T> {
+    pub fn get(&self, index: Index) -> Option<&T> {
         if index.is_none() { return None; }
         self.elems.get(index.get().unwrap())?.as_ref()
     }
     #[inline]
     pub fn get_mut_first(&mut self) -> Option<&mut T> {
-        self.get_mut_index(self.first_index())
+        self.get_mut(self.first_index())
     }
     #[inline]
     pub fn get_mut_last(&mut self) -> Option<&mut T> {
-        self.get_mut_index(self.last_index())
+        self.get_mut(self.last_index())
     }
     #[inline]
-    pub fn get_mut_index(&mut self, index: Index) -> Option<&mut T> {
+    pub fn get_mut(&mut self, index: Index) -> Option<&mut T> {
         if let Some(ndx) = index.get() {
             if ndx < self.len() {
                 self.elems[ndx].as_mut()
@@ -271,12 +262,12 @@ impl<T> IndexList<T> {
     #[inline]
     // Peek at next element data, if any
     pub fn peek_next(&self, index: Index) -> Option<&T> {
-        self.get_index(self.next_index(index))
+        self.get(self.next_index(index))
     }
     #[inline]
     // Peek at previous element data, if any
     pub fn peek_prev(&self, index: Index) -> Option<&T> {
-        self.get_index(self.prev_index(index))
+        self.get(self.prev_index(index))
     }
     #[inline]
     pub fn contains(&self, elem: T) -> bool
@@ -312,12 +303,12 @@ impl<T> IndexList<T> {
         Index::from(pos)
     }
     pub fn remove_first(&mut self) -> Option<T> {
-        self.remove_index(self.first_index())
+        self.remove(self.first_index())
     }
     pub fn remove_last(&mut self) -> Option<T> {
-        self.remove_index(self.last_index())
+        self.remove(self.last_index())
     }
-    pub fn remove_index(&mut self, index: Index) -> Option<T> {
+    pub fn remove(&mut self, index: Index) -> Option<T> {
         if index.is_none() { return None; }
         let ndx = index.get().unwrap();
         if ndx >= self.nodes.len() { return None; }
@@ -430,16 +421,20 @@ impl<T> IndexList<T> {
     }
     #[allow(dead_code)]
     #[inline]
-    fn set_prev(&mut self, index: Index, new_prev: Index) {
+    fn set_prev(&mut self, index: Index, new_prev: Index) -> Index {
         if let Some(at) = index.get() {
-            self.get_mut_indexnode(at).new_prev(new_prev);
+            self.get_mut_indexnode(at).new_prev(new_prev)
+        } else {
+            index
         }
     }
     #[allow(dead_code)]
     #[inline]
-    fn set_next(&mut self, index: Index, new_next: Index) {
+    fn set_next(&mut self, index: Index, new_next: Index) -> Index {
         if let Some(at) = index.get() {
-            self.get_mut_indexnode(at).new_next(new_next);
+            self.get_mut_indexnode(at).new_next(new_next)
+        } else {
+            index
         }
     }
     #[inline]
@@ -615,7 +610,7 @@ impl<'a, T> Iterator for Iter<'a, T> {
     type Item = &'a T;
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        let item = self.list.get_index(self.curr);
+        let item = self.list.get(self.curr);
         self.curr = self.list.next_index(self.curr);
         item
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,26 +1,104 @@
 use std::fmt;
+use std::num::NonZeroU32;
+use std::convert::TryFrom;
 
-pub type Index = usize;
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct Index(Option<NonZeroU32>);
+
+impl Index {
+    #[inline]
+    fn new() -> Index {
+        Index { 0: None }
+    }
+    #[allow(dead_code)]
+    #[inline]
+    pub fn is_some(&self) -> bool {
+        self.0.is_some()
+    }
+    #[inline]
+    pub fn is_none(&self) -> bool {
+        self.0.is_none()
+    }
+    #[inline]
+    fn get(&self) -> Option<usize> {
+        Some(self.0?.get() as usize - 1)
+    }
+    #[inline]
+    pub fn get_raw(&self) -> u32 {
+        if let Some(n) = self.0 {
+            n.get()
+        } else {
+            0
+        }
+    }
+    #[inline]
+    fn set(mut self, index: Option<usize>) -> Self {
+        if let Some(n) = index {
+            if let Ok(num) = NonZeroU32::try_from(n as u32 + 1) {
+                self.0 = Some(num);
+            } else {
+                self.0 = None;
+            }
+        } else {
+            self.0 = None;
+        }
+        self
+    }
+}
+
+impl From<u32> for Index {
+    fn from(index: u32) -> Index {
+        Index::new().set(Some(index as usize))
+    }
+}
+
+impl From<u64> for Index {
+    fn from(index: u64) -> Index {
+        Index::new().set(Some(index as usize))
+    }
+}
+
+impl From<usize> for Index {
+    fn from(index: usize) -> Index {
+        Index::new().set(Some(index))
+    }
+}
+
+impl From<Option<usize>> for Index {
+    fn from(index: Option<usize>) -> Index {
+        Index::new().set(index)
+    }
+}
+
+impl fmt::Display for Index {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if let Some(ndx) = self.0 {
+            write!(f, "{}", ndx)
+        } else {
+            write!(f, "|")
+        }
+    }
+}
 
 #[derive(Clone, Debug, Default)]
 struct IndexNode {
-    next: Option<Index>,
-    prev: Option<Index>,
+    next: Index,
+    prev: Index,
 }
 
 impl IndexNode {
     #[inline]
     pub fn new() -> IndexNode {
-        IndexNode { next: None, prev: None }
+        IndexNode { next: Index::new(), prev: Index::new() }
     }
     #[inline]
-    pub fn new_next(&mut self, next: Option<Index>) -> Option<Index> {
+    pub fn new_next(&mut self, next: Index) -> Index {
         let old_next = self.next;
         self.next = next;
         old_next
     }
     #[inline]
-    pub fn new_prev(&mut self, prev: Option<Index>) -> Option<Index> {
+    pub fn new_prev(&mut self, prev: Index) -> Index {
         let old_prev = self.prev;
         self.prev = prev;
         old_prev
@@ -29,43 +107,43 @@ impl IndexNode {
 
 impl fmt::Display for IndexNode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}<->{:?}", self.next, self.prev)
+        write!(f, "{}<>{}", self.next, self.prev)
     }
 }
 
 #[derive(Clone, Debug, Default)]
 struct IndexEnds {
-    head: Option<Index>,
-    tail: Option<Index>,
+    head: Index,
+    tail: Index,
 }
 
 impl IndexEnds {
     #[inline]
     pub fn new() -> Self {
-        IndexEnds { head: None, tail: None }
+        IndexEnds { head: Index::new(), tail: Index::new() }
     }
     #[inline]
     pub fn clear(&mut self) {
-        self.new_both(None);
+        self.new_both(Index::new());
     }
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.head.is_none()
     }
     #[inline]
-    pub fn new_head(&mut self, head: Option<Index>) -> Option<Index> {
+    pub fn new_head(&mut self, head: Index) -> Index {
         let old_head = self.head;
         self.head = head;
         old_head
     }
     #[inline]
-    pub fn new_tail(&mut self, tail: Option<Index>) -> Option<Index> {
+    pub fn new_tail(&mut self, tail: Index) -> Index {
         let old_tail = self.tail;
         self.tail = tail;
         old_tail
     }
     #[inline]
-    pub fn new_both(&mut self, both: Option<Index>) {
+    pub fn new_both(&mut self, both: Index) {
         self.head = both;
         self.tail = both;
     }
@@ -73,7 +151,7 @@ impl IndexEnds {
 
 impl fmt::Display for IndexEnds {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}=> ... <={:?}", self.head, self.tail)
+        write!(f, "{}>=<{}", self.head, self.tail)
     }
 }
 
@@ -124,52 +202,68 @@ impl<T> IndexList<T> {
     }
     #[inline]
     pub fn is_index_used(&self, index: Index) -> bool {
-        if let Some(data) = self.elems.get(index) {
+        if index.is_none() { return false; }
+        if let Some(data) = self.elems.get(index.get().unwrap()) {
             data.is_some()
         } else {
             false
         }
     }
     #[inline]
-    pub fn first_index(&self) -> Option<Index> {
+    pub fn first_index(&self) -> Index {
         self.used.head
     }
     #[inline]
-    pub fn last_index(&self) -> Option<Index> {
+    pub fn last_index(&self) -> Index {
         self.used.tail
     }
     #[inline]
-    pub fn next_index(&self, index: Index) -> Option<Index> {
-        self.nodes.get(index)?.next
+    pub fn next_index(&self, index: Index) -> Index {
+        if index.is_none() { return index; }
+        if let Some(node) = self.nodes.get(index.get().unwrap()) {
+            node.next
+        } else {
+            Index::new()
+        }
     }
     #[inline]
-    pub fn prev_index(&self, index: Index) -> Option<Index> {
-        self.nodes.get(index)?.prev
+    pub fn prev_index(&self, index: Index) -> Index {
+        if index.is_none() { return index; }
+        if let Some(node) = self.nodes.get(index.get().unwrap()) {
+            node.prev
+        } else {
+            Index::new()
+        }
     }
     #[inline]
     pub fn get_first(&self) -> Option<&T> {
-        self.get_index(self.first_index()?)
+        self.get_index(self.first_index())
     }
     #[inline]
     pub fn get_last(&self) -> Option<&T> {
-        self.get_index(self.last_index()?)
+        self.get_index(self.last_index())
     }
     #[inline]
     pub fn get_index(&self, index: Index) -> Option<&T> {
-        self.elems.get(index)?.as_ref()
+        if index.is_none() { return None; }
+        self.elems.get(index.get().unwrap())?.as_ref()
     }
     #[inline]
     pub fn get_mut_first(&mut self) -> Option<&mut T> {
-        self.get_mut_index(self.first_index()?)
+        self.get_mut_index(self.first_index())
     }
     #[inline]
     pub fn get_mut_last(&mut self) -> Option<&mut T> {
-        self.get_mut_index(self.last_index()?)
+        self.get_mut_index(self.last_index())
     }
     #[inline]
     pub fn get_mut_index(&mut self, index: Index) -> Option<&mut T> {
-        if index < self.len() {
-            self.elems[index].as_mut()
+        if let Some(ndx) = index.get() {
+            if ndx < self.len() {
+                self.elems[ndx].as_mut()
+            } else {
+                None
+            }
         } else {
             None
         }
@@ -177,12 +271,12 @@ impl<T> IndexList<T> {
     #[inline]
     // Peek at next element data, if any
     pub fn peek_next(&self, index: Index) -> Option<&T> {
-        self.get_index(self.next_index(index)?)
+        self.get_index(self.next_index(index))
     }
     #[inline]
     // Peek at previous element data, if any
     pub fn peek_prev(&self, index: Index) -> Option<&T> {
-        self.get_index(self.prev_index(index)?)
+        self.get_index(self.prev_index(index))
     }
     #[inline]
     pub fn contains(&self, elem: T) -> bool
@@ -192,35 +286,45 @@ impl<T> IndexList<T> {
     pub fn insert_first(&mut self, elem: T) -> Index {
         let pos = self.new_node(Some(elem));
         self.linkin_first(pos, Some(true));
-        pos
+        Index::from(pos)
     }
     pub fn insert_last(&mut self, elem: T) -> Index {
         let pos = self.new_node(Some(elem));
         self.linkin_last(pos, Some(true));
-        pos
+        Index::from(pos)
     }
     pub fn insert_before(&mut self, index: Index, elem: T) -> Index {
+        if index.is_none() {
+            return self.insert_first(elem);
+        }
+        let ndx = index.get().unwrap();
         let pos = self.new_node(Some(elem));
-        self.linkin_this_before_that(pos, index);
-        pos
+        self.linkin_this_before_that(pos, ndx);
+        Index::from(pos)
     }
     pub fn insert_after(&mut self, index: Index, elem: T) -> Index {
+        if index.is_none() {
+            return self.insert_last(elem);
+        }
+        let ndx = index.get().unwrap();
         let pos = self.new_node(Some(elem));
-        self.linkin_this_after_that(pos, index);
-        pos
+        self.linkin_this_after_that(pos, ndx);
+        Index::from(pos)
     }
     pub fn remove_first(&mut self) -> Option<T> {
-        self.remove_index(self.first_index()?)
+        self.remove_index(self.first_index())
     }
     pub fn remove_last(&mut self) -> Option<T> {
-        self.remove_index(self.last_index()?)
+        self.remove_index(self.last_index())
     }
     pub fn remove_index(&mut self, index: Index) -> Option<T> {
-        if index >= self.nodes.len() { return None; }
-        let elem = self.remove_elem_at_index(index);
-        debug_assert!(self.elems[index].is_none());
-        self.linkout(index, Some(true));
-        self.insert_free_node(index);
+        if index.is_none() { return None; }
+        let ndx = index.get().unwrap();
+        if ndx >= self.nodes.len() { return None; }
+        let elem = self.remove_elem_at_index(ndx);
+        debug_assert!(self.elems[ndx].is_none());
+        self.linkout(ndx, Some(true));
+        self.insert_free_node(ndx);
         elem
     }
     #[inline]
@@ -239,12 +343,12 @@ impl<T> IndexList<T> {
     }
     /// Remove some unused indexes at the end by truncating, if any
     pub fn trim_safe(&mut self) {
-        let removed: Vec<Index> = (self.len()..self.capacity())
+        let removed: Vec<usize> = (self.len()..self.capacity())
             .rev()
-            .take_while(|&x| self.is_index_free(x))
+            .take_while(|&i| self.is_free(i))
             .collect();
-        removed.iter().for_each(|&x| {
-            self.linkout(x, Some(false));
+        removed.iter().for_each(|&i| {
+            self.linkout(i, Some(false));
         });
         if removed.len() > 0 {
             let left = self.capacity() - removed.len();
@@ -257,14 +361,14 @@ impl<T> IndexList<T> {
     pub fn trim_swap(&mut self) {
         let need = self.size;
         // destination is all free node indexes below the needed limit
-        let dst: Vec<Index> = self.elems[..need]
+        let dst: Vec<usize> = self.elems[..need]
             .iter()
             .enumerate()
             .filter(|(n, e)| e.is_none() && n < &need)
             .map(|(n, _e)| n)
             .collect();
         // source is all used node indexes above the needed limit
-        let src: Vec<Index> = self.elems[need..]
+        let src: Vec<usize> = self.elems[need..]
             .iter()
             .enumerate()
             .filter(|(_n, e)| e.is_some())
@@ -274,64 +378,81 @@ impl<T> IndexList<T> {
         src.iter()
             .zip(dst.iter())
             .for_each(|(s, d)| self.replace_dest_index(*s, *d));
-        self.free.new_both(None);
+        self.free.new_both(Index::new());
         self.elems.truncate(need);
         self.nodes.truncate(need);
     }
-    /// Add the elements from the other list after the elements of this
+    /// Add the elements of the other list after the elements of this list
     pub fn append(&mut self, other: &mut IndexList<T>) {
-        if other.is_empty() { return; }
-        other.trim_swap(); // Do not to copy any unused nodes.
-        let offset = self.capacity() as Index;
-        self.elems.append(&mut other.elems);
-        self.nodes.append(&mut other.nodes);
-        self.nodes[offset..].iter_mut().for_each(|node| {
-            if let Some(next_pos) = node.next {
-                node.next = Some(next_pos + offset);
+        while let Some(elem) = other.remove_first() {
+            self.insert_last(elem);
+        }
+    }
+    /// Add the element of the other list before the element of this list
+    pub fn prepend(&mut self, other: &mut IndexList<T>) {
+        while let Some(elem) = other.remove_last() {
+            self.insert_first(elem);
+        }
+    }
+    /// Split the elements at this index and after to a new list
+    pub fn split(&mut self, index: Index) -> IndexList<T> {
+        let mut list = IndexList::<T>::new();
+        if index.is_none() {
+            return list;
+        }
+        loop {
+            let last = self.last_index();
+            if last.is_none() {
+                break;
             }
-            if let Some(prev_pos) = node.prev {
-                node.prev = Some(prev_pos + offset);
+            list.insert_first(self.remove_last().unwrap());
+            if last == index {
+                break;
             }
-        });
-        let other_head_pos = other.first_index().unwrap() + offset;
-        self.set_prev(other_head_pos, self.last_index());
-        self.set_next(self.last_index().unwrap(), Some(other_head_pos));
-        let other_tail_pos = other.last_index().unwrap() + offset;
-        self.used.new_tail(Some(other_tail_pos));
-        self.size += other.size;
+        }
+        list
     }
 
     #[inline]
-    fn is_index_free(&self, index: Index) -> bool {
-        self.elems[index].is_none()
+    fn is_used(&self, at: usize) -> bool {
+        self.elems[at].is_some()
+    }
+    fn is_free(&self, at: usize) -> bool {
+        self.elems[at].is_none()
     }
     #[inline]
-    fn get_mut_indexnode(&mut self, at: Index) -> &mut IndexNode {
+    fn get_mut_indexnode(&mut self, at: usize) -> &mut IndexNode {
         &mut self.nodes[at]
     }
     #[inline]
-    fn get_indexnode(&self, at: Index) -> &IndexNode {
+    fn get_indexnode(&self, at: usize) -> &IndexNode {
         &self.nodes[at]
     }
+    #[allow(dead_code)]
     #[inline]
-    fn set_prev(&mut self, at: Index, new_prev: Option<Index>) {
-        self.get_mut_indexnode(at).new_prev(new_prev);
+    fn set_prev(&mut self, index: Index, new_prev: Index) {
+        if let Some(at) = index.get() {
+            self.get_mut_indexnode(at).new_prev(new_prev);
+        }
+    }
+    #[allow(dead_code)]
+    #[inline]
+    fn set_next(&mut self, index: Index, new_next: Index) {
+        if let Some(at) = index.get() {
+            self.get_mut_indexnode(at).new_next(new_next);
+        }
     }
     #[inline]
-    fn set_next(&mut self, at: Index, new_next: Option<Index>) {
-        self.get_mut_indexnode(at).new_next(new_next);
-    }
-    #[inline]
-    fn insert_elem_at_index(&mut self, at: Index, elem: Option<T>) {
+    fn insert_elem_at_index(&mut self, at: usize, elem: Option<T>) {
         self.elems[at] = elem;
         self.size += 1;
     }
     #[inline]
-    fn remove_elem_at_index(&mut self, at: Index) -> Option<T> {
+    fn remove_elem_at_index(&mut self, at: usize) -> Option<T> {
         self.size -= 1;
         self.elems[at].take()
     }
-    fn new_node(&mut self, elem: Option<T>) -> Index {
+    fn new_node(&mut self, elem: Option<T>) -> usize {
         if let Some(pos) = self.remove_free_node() {
             self.insert_elem_at_index(pos, elem);
             pos
@@ -343,125 +464,125 @@ impl<T> IndexList<T> {
             pos
         }
     }
-    fn remove_free_node(&mut self) -> Option<Index> {
-        if let Some(head_pos) = self.free.head {
+    fn remove_free_node(&mut self) -> Option<usize> {
+        if let Some(head_pos) = self.free.head.get() {
             self.linkout(head_pos, Some(false));
             Some(head_pos)
         } else {
             None
         }
     }
-    fn insert_free_node(&mut self, this: Index) {
-        debug_assert!(self.is_index_free(this));
-        self.linkin_last(this, Some(false));
+    fn insert_free_node(&mut self, at: usize) {
+        debug_assert!(self.is_free(at));
+        self.linkin_last(at, Some(false));
     }
-    fn linkin_first(&mut self, this: Index, is_used: Option<bool>) {
-        let is_used = is_used.unwrap_or(self.is_index_used(this));
-        let old_head_opt = if is_used { self.used.head } else { self.free.head };
-        if let Some(old_head_pos) = old_head_opt {
+    fn linkin_first(&mut self, this: usize, is_used: Option<bool>) {
+        let is_used = is_used.unwrap_or(self.is_used(this));
+        let old_head_ndx = if is_used { self.used.head } else { self.free.head };
+        if let Some(old_head_pos) = old_head_ndx.get() {
             let old_head = self.get_mut_indexnode(old_head_pos);
-            let old_head_prev = old_head.new_prev(Some(this));
-            debug_assert_eq!(old_head_prev, None);
+            let old_head_prev = old_head.new_prev(Index::from(this));
+            debug_assert_eq!(old_head_prev.get(), None);
             let this_node = self.get_mut_indexnode(this);
-            let old_next = this_node.new_next(Some(old_head_pos));
-            debug_assert_eq!(old_next, None);
+            let old_next = this_node.new_next(Index::from(old_head_pos));
+            debug_assert_eq!(old_next.get(), None);
         }
         let list = if is_used { &mut self.used } else { &mut self.free };
-        if list.new_head(Some(this)).is_none() {
+        if list.new_head(Index::from(this)).is_none() {
             if list.is_empty() {
-                list.new_both(Some(this));
+                list.new_both(Index::from(this));
             } else {
-                let old_prev = list.new_tail(Some(this));
-                debug_assert_eq!(old_prev, None);
+                let old_prev_ndx = list.new_tail(Index::from(this));
+                debug_assert_eq!(old_prev_ndx.get(), None);
             }
         }
     }
-    fn linkin_last(&mut self, this: Index, is_used: Option<bool>) {
-        let is_used = is_used.unwrap_or(self.is_index_used(this));
-        let old_tail_opt = if is_used { self.used.tail } else { self.free.tail };
-        if let Some(old_tail_pos) = old_tail_opt {
+    fn linkin_last(&mut self, this: usize, is_used: Option<bool>) {
+        let is_used = is_used.unwrap_or(self.is_used(this));
+        let old_tail_ndx = if is_used { self.used.tail } else { self.free.tail };
+        if let Some(old_tail_pos) = old_tail_ndx.get() {
             let old_tail = self.get_mut_indexnode(old_tail_pos);
-            let old_tail_next = old_tail.new_next(Some(this));
-            debug_assert_eq!(old_tail_next, None);
+            let old_tail_next = old_tail.new_next(Index::from(this));
+            debug_assert_eq!(old_tail_next.get(), None);
             let this_node = self.get_mut_indexnode(this);
-            let old_prev = this_node.new_prev(Some(old_tail_pos));
-            debug_assert_eq!(old_prev, None);
+            let old_prev = this_node.new_prev(Index::from(old_tail_pos));
+            debug_assert_eq!(old_prev.get(), None);
         }
         let list = if is_used { &mut self.used } else { &mut self.free };
-        if list.new_tail(Some(this)).is_none() {
+        if list.new_tail(Index::from(this)).is_none() {
             if list.is_empty() {
-                list.new_both(Some(this));
+                list.new_both(Index::from(this));
             } else {
-                let old_head_opt = list.new_head(Some(this));
-                debug_assert_eq!(old_head_opt, None);
+                let old_head = list.new_head(Index::from(this));
+                debug_assert_eq!(old_head.get(), None);
             }
         }
     }
-    fn linkin_this_before_that(&mut self, this: Index, that: Index) {
+    fn linkin_this_before_that(&mut self, this: usize, that: usize) {
         let next = self.get_mut_indexnode(that);
-        let before = next.new_prev(Some(this));
+        let before = next.new_prev(Index::from(this));
         let node = self.get_mut_indexnode(this);
         node.new_prev(before);
-        node.new_next(Some(that));
-        if let Some(prev_pos) = before {
+        node.new_next(Index::from(that));
+        if let Some(prev_pos) = before.get() {
             let prev = self.get_mut_indexnode(prev_pos);
-            let old_next = prev.new_next(Some(this));
-            debug_assert_eq!(old_next, Some(that));
+            let old_next_ndx = prev.new_next(Index::from(this));
+            debug_assert_eq!(old_next_ndx.get(), Some(that));
         } else {
-            let old_next = self.used.new_head(Some(this));
-            debug_assert_eq!(old_next, Some(that));
+            let old_next_ndx = self.used.new_head(Index::from(this));
+            debug_assert_eq!(old_next_ndx, Index::from(that));
         }
     }
-    fn linkin_this_after_that(&mut self, this: Index, that: Index) {
+    fn linkin_this_after_that(&mut self, this: usize, that: usize) {
         let prev = self.get_mut_indexnode(that);
-        let next_opt = prev.new_next(Some(this));
+        let next_opt = prev.new_next(Index::from(this));
         let node = self.get_mut_indexnode(this);
         node.new_next(next_opt);
-        node.new_prev(Some(that));
-        if let Some(next_pos) = next_opt {
+        node.new_prev(Index::from(that));
+        if let Some(next_pos) = next_opt.get() {
             let next = self.get_mut_indexnode(next_pos);
-            let old_prev = next.new_prev(Some(this));
-            debug_assert_eq!(old_prev, Some(that));
+            let old_prev = next.new_prev(Index::from(this));
+            debug_assert_eq!(old_prev, Index::from(that));
         } else {
-            let old_prev = self.used.new_tail(Some(this));
-            debug_assert_eq!(old_prev, Some(that));
+            let old_prev = self.used.new_tail(Index::from(this));
+            debug_assert_eq!(old_prev, Index::from(that));
         }
     }
-    fn linkout(&mut self, this: Index, is_used: Option<bool>) {
+    fn linkout(&mut self, this: usize, is_used: Option<bool>) {
         let node = self.get_mut_indexnode(this);
-        let next_opt = node.new_next(None);
-        let prev_opt = node.new_prev(None);
-        if let Some(next_pos) = next_opt {
+        let next_opt = node.new_next(Index::new());
+        let prev_opt = node.new_prev(Index::new());
+        if let Some(next_pos) = next_opt.get() {
             let next = self.get_mut_indexnode(next_pos);
             let old_prev = next.new_prev(prev_opt);
-            debug_assert_eq!(old_prev, Some(this));
+            debug_assert_eq!(old_prev, Index::from(this));
         }
-        if let Some(prev_pos) = prev_opt {
+        if let Some(prev_pos) = prev_opt.get() {
             let prev = self.get_mut_indexnode(prev_pos);
             let old_next = prev.new_next(next_opt);
-            debug_assert_eq!(old_next, Some(this));
+            debug_assert_eq!(old_next, Index::from(this));
         }
-        let is_used = is_used.unwrap_or(self.is_index_used(this));
+        let is_used = is_used.unwrap_or(self.is_used(this));
         let list = if is_used { &mut self.used } else { &mut self.free };
         if next_opt.is_none() {
             let old_prev = list.new_tail(prev_opt);
-            debug_assert_eq!(old_prev, Some(this));
+            debug_assert_eq!(old_prev, Index::from(this));
         }
         if prev_opt.is_none() {
             let old_next = list.new_head(next_opt);
-            debug_assert_eq!(old_next, Some(this));
+            debug_assert_eq!(old_next, Index::from(this));
         }
     }
-    fn replace_dest_index(&mut self, src: Index, dst: Index) {
+    fn replace_dest_index(&mut self, src: usize, dst: usize) {
         self.linkout(dst, Some(false));
         let src_node = self.get_indexnode(src);
         let src_next_opt = src_node.next;
         let src_prev_opt = src_node.prev;
         self.linkout(src, Some(true));
         self.elems[dst] = self.elems[src].take();
-        if let Some(next_pos) = src_next_opt {
+        if let Some(next_pos) = src_next_opt.get() {
             self.linkin_this_before_that(dst, next_pos);
-        } else if let Some(prev_pos) = src_prev_opt {
+        } else if let Some(prev_pos) = src_prev_opt.get() {
             self.linkin_this_after_that(dst, prev_pos);
         } else {
             self.linkin_first(dst, Some(true));
@@ -487,19 +608,16 @@ impl<T> From<T> for IndexList<T> {
 
 pub struct Iter<'a, T> {
     list: &'a IndexList<T>,
-    curr: Option<Index>,
+    curr: Index,
 }
 
 impl<'a, T> Iterator for Iter<'a, T> {
     type Item = &'a T;
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some(this) = self.curr {
-            self.curr = self.list.next_index(this);
-            self.list.get_index(this)
-        } else {
-            None
-        }
+        let item = self.list.get_index(self.curr);
+        self.curr = self.list.next_index(self.curr);
+        item
     }
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -17,6 +17,9 @@ fn debug_print_indexes(list: &IndexList<u64>) {
     }
     println!(" ]");
 }
+fn get_raw_index(index: &Index) -> u32 {
+    index.to_string().parse::<u32>().unwrap_or(0)
+}
 
 #[test]
 fn test_instantiate() {
@@ -29,12 +32,16 @@ fn test_instantiate() {
     assert_eq!(list.last_index(), null);
     assert_eq!(list.next_index(null), null);
     assert_eq!(list.prev_index(null), null);
-    assert_eq!(list.get_index(null), None);
-    assert_eq!(list.get_mut_index(null), None);
+    assert_eq!(list.get(null), None);
+    assert_eq!(list.get_mut(null), None);
     assert_eq!(list.remove_first(), None);
     assert_eq!(list.remove_last(), None);
-    assert_eq!(list.remove_index(null), None);
+    assert_eq!(list.remove(null), None);
     assert_eq!(list.to_vec(), Vec::<&u64>::new());
+    let mut empty_list = IndexList::new();
+    list.append(&mut empty_list);
+    list.prepend(&mut empty_list);
+    list.split(null);
     list.trim_safe();
     list.trim_swap();
 }
@@ -68,7 +75,7 @@ fn test_append() {
     list.append(&mut other);
     assert_eq!(list.len(), 6);
     assert_eq!(list.capacity(), 6);
-    assert_eq!(list.get_index(Index::from(3u32)), Some(&"D"));
+    assert_eq!(list.get(Index::from(3u32)), Some(&"D"));
     let parts: Vec<&str> = list.iter().map(|e| e.as_ref()).collect();
     assert_eq!(parts.join(", "), "A, B, C, D, E, F");
 }
@@ -85,7 +92,7 @@ fn test_trim_swap() {
         let mut indexes: Vec<usize> = (0..list.capacity()).collect();
         indexes.shuffle(&mut rng);
         (0..8).for_each(|_| {
-            list.remove_index(Index::from(indexes.pop()));
+            list.remove(Index::from(indexes.pop()));
         });
         debug_print_indexes(&list);
         list.trim_swap();
@@ -127,26 +134,26 @@ fn insert_remove_variants() {
                 0 => {
                     let ndx = list.insert_first(num);
                     println!("first - index {}", ndx);
-                    indexes.push(ndx.get_raw());
+                    indexes.push(get_raw_index(&ndx));
                 },
                 1 => {
                     let that = Index::from(indexes[rng.gen_range(0..c)] - 1);
                     print!("before {} ", that);
                     let ndx = list.insert_before(that, num);
                     println!("- index {}", ndx);
-                    indexes.push(ndx.get_raw());
+                    indexes.push(get_raw_index(&ndx));
                 },
                 2 => {
                     let that = Index::from(indexes[rng.gen_range(0..c)] - 1);
                     print!("after {} ", that);
                     let ndx = list.insert_after(that, num);
                     println!("- index {}", ndx);
-                    indexes.push(ndx.get_raw());
+                    indexes.push(get_raw_index(&ndx));
                 },
                 _ => {
                     let ndx = list.insert_last(num);
                     println!("last - index {}", ndx);
-                    indexes.push(ndx.get_raw());
+                    indexes.push(get_raw_index(&ndx));
                 },
             }
             print!("IndexList: ");
@@ -157,7 +164,7 @@ fn insert_remove_variants() {
             let ndx = Index::from(
                 indexes.swap_remove(rng.gen_range(0..c as usize)) - 1);
             println!("IndexList - remove {}", ndx);
-            let num = list.remove_index(ndx).unwrap();
+            let num = list.remove(ndx).unwrap();
             //println!("IndexList: {}", list.to_debug_string());
             assert!(numbers.remove(&num));
         }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -4,16 +4,16 @@ use rand::{Rng, seq::SliceRandom};
 
 fn debug_print_indexes(list: &IndexList<u64>) {
     let mut index = list.first_index();
-    let mut last = None;
+    let mut last = Index::from(None);
     print!("[ ");
-    while let Some(ndx) = index {
+    while index.is_some() {
         if last.is_some() {
             print!(" >< ");
         }
-        print!("{}", ndx);
-        debug_assert_eq!(list.prev_index(ndx), last);
+        print!("{}", index);
+        debug_assert_eq!(list.prev_index(index), last);
         last = index;
-        index = list.next_index(ndx);
+        index = list.next_index(index);
     }
     println!(" ]");
 }
@@ -21,18 +21,19 @@ fn debug_print_indexes(list: &IndexList<u64>) {
 #[test]
 fn test_instantiate() {
     let mut list = IndexList::<u64>::new();
+    let null = Index::from(None);
     assert_eq!(list.len(), 0);
     assert_eq!(list.capacity(), 0);
-    assert_eq!(list.is_index_used(0), false);
-    assert_eq!(list.first_index(), None);
-    assert_eq!(list.last_index(), None);
-    assert_eq!(list.next_index(0), None);
-    assert_eq!(list.prev_index(0), None);
-    assert_eq!(list.get_index(0), None);
-    assert_eq!(list.get_mut_index(0), None);
+    assert_eq!(list.is_index_used(null), false);
+    assert_eq!(list.first_index(), null);
+    assert_eq!(list.last_index(), null);
+    assert_eq!(list.next_index(null), null);
+    assert_eq!(list.prev_index(null), null);
+    assert_eq!(list.get_index(null), None);
+    assert_eq!(list.get_mut_index(null), None);
     assert_eq!(list.remove_first(), None);
     assert_eq!(list.remove_last(), None);
-    assert_eq!(list.remove_index(0), None);
+    assert_eq!(list.remove_index(null), None);
     assert_eq!(list.to_vec(), Vec::<&u64>::new());
     list.trim_safe();
     list.trim_swap();
@@ -51,7 +52,7 @@ fn basic_insert_remove() {
     list.trim_swap();
     (0..count).rev().for_each(|i| {
         assert_eq!(list.remove_first(), Some(i));
-        assert_eq!(list.is_index_used(i as Index), false);
+        assert_eq!(list.is_index_used(Index::from(i as usize)), false);
         assert_eq!(list.len(), i as usize);
     });
     assert_eq!(list.remove_first(), None);
@@ -67,7 +68,7 @@ fn test_append() {
     list.append(&mut other);
     assert_eq!(list.len(), 6);
     assert_eq!(list.capacity(), 6);
-    assert_eq!(list.get_index(3), Some(&"D"));
+    assert_eq!(list.get_index(Index::from(3u32)), Some(&"D"));
     let parts: Vec<&str> = list.iter().map(|e| e.as_ref()).collect();
     assert_eq!(parts.join(", "), "A, B, C, D, E, F");
 }
@@ -84,7 +85,7 @@ fn test_trim_swap() {
         let mut indexes: Vec<usize> = (0..list.capacity()).collect();
         indexes.shuffle(&mut rng);
         (0..8).for_each(|_| {
-            list.remove_index(indexes.pop().unwrap());
+            list.remove_index(Index::from(indexes.pop()));
         });
         debug_print_indexes(&list);
         list.trim_swap();
@@ -116,7 +117,7 @@ fn insert_remove_variants() {
     let mut rng = rand::thread_rng();
     let mut list = IndexList::<u64>::new();
     let mut numbers: HashSet<u64> = HashSet::with_capacity(count);
-    let mut indexes: Vec<usize> = Vec::with_capacity(count);
+    let mut indexes: Vec<u32> = Vec::with_capacity(count);
     for _ in 0..8 {
         for c in 0..count {
             let num = c as u64;
@@ -126,26 +127,26 @@ fn insert_remove_variants() {
                 0 => {
                     let ndx = list.insert_first(num);
                     println!("first - index {}", ndx);
-                    indexes.push(ndx);
+                    indexes.push(ndx.get_raw());
                 },
                 1 => {
-                    let that = indexes[rng.gen_range(0..c)];
+                    let that = Index::from(indexes[rng.gen_range(0..c)] - 1);
                     print!("before {} ", that);
                     let ndx = list.insert_before(that, num);
                     println!("- index {}", ndx);
-                    indexes.push(ndx);
+                    indexes.push(ndx.get_raw());
                 },
                 2 => {
-                    let that = indexes[rng.gen_range(0..c)];
+                    let that = Index::from(indexes[rng.gen_range(0..c)] - 1);
                     print!("after {} ", that);
                     let ndx = list.insert_after(that, num);
                     println!("- index {}", ndx);
-                    indexes.push(ndx);
+                    indexes.push(ndx.get_raw());
                 },
                 _ => {
                     let ndx = list.insert_last(num);
                     println!("last - index {}", ndx);
-                    indexes.push(ndx);
+                    indexes.push(ndx.get_raw());
                 },
             }
             print!("IndexList: ");
@@ -153,7 +154,8 @@ fn insert_remove_variants() {
         }
         assert_eq!(list.len(), count);
         for c in (1..=count).rev() {
-            let ndx = indexes.swap_remove(rng.gen_range(0..c as usize));
+            let ndx = Index::from(
+                indexes.swap_remove(rng.gen_range(0..c as usize)) - 1);
             println!("IndexList - remove {}", ndx);
             let num = list.remove_index(ndx).unwrap();
             //println!("IndexList: {}", list.to_debug_string());

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -129,30 +129,30 @@ fn insert_remove_variants() {
         for c in 0..count {
             let num = c as u64;
             numbers.insert(num);
-            print!("IndexList#{}:insert ", num);
+            print!("IndexList#{}: insert ", num);
             match c & 3 {
                 0 => {
                     let ndx = list.insert_first(num);
-                    println!("first - index {}", ndx);
+                    println!("index {} first", ndx);
                     indexes.push(get_raw_index(&ndx));
                 },
                 1 => {
                     let that = Index::from(indexes[rng.gen_range(0..c)] - 1);
                     print!("before {} ", that);
                     let ndx = list.insert_before(that, num);
-                    println!("- index {}", ndx);
+                    println!("index {}", ndx);
                     indexes.push(get_raw_index(&ndx));
                 },
                 2 => {
                     let that = Index::from(indexes[rng.gen_range(0..c)] - 1);
                     print!("after {} ", that);
                     let ndx = list.insert_after(that, num);
-                    println!("- index {}", ndx);
+                    println!("index {} ", ndx);
                     indexes.push(get_raw_index(&ndx));
                 },
                 _ => {
                     let ndx = list.insert_last(num);
-                    println!("last - index {}", ndx);
+                    println!("index {} last", ndx);
                     indexes.push(get_raw_index(&ndx));
                 },
             }


### PR DESCRIPTION
Implement Index as struct(Option<NonZeroU32>).

Refactor the code to use the new Index type.

Add prepend and split methods. Reimplement append more concisely.
