### PR TITLE
WIP: add `IndexList::move_to_last` to maintain `ListIndex`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -564,6 +564,16 @@ impl<T> IndexList<T> {
         }
         elem_opt
     }
+    /// Move the element at the index to the end.
+    /// The index remains the same.
+    pub fn move_to_last(&mut self, index: ListIndex) {
+        if self.is_index_used(index) {
+            // unlink where it is
+            self.linkout_used(index);
+            // insert it as last
+            self.linkin_last(index);
+        }
+    }
     /// Create a new iterator over all the elements.
     ///
     /// Example:

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -60,6 +60,7 @@ fn test_instantiate() {
     list.split(null);
     list.trim_safe();
     list.trim_swap();
+    list.move_to_last(ListIndex::new())
 }
 #[test]
 fn basic_insert_remove() {


### PR DESCRIPTION
This is a work in progress. I will need help discussing if you require something more than this. I need to write a doc example if you find the basics of this PR acceptable. I can also write unit tests for this method. I am holding off on those until I get a preliminary review. Thank you.

There is value for the API to allow an entry in the list to be moved to the end of the linked list while maintaining the same index.
An example use case is implementing an LRU algorithm.
When an entry is found in a separate `HashMap`, we need to move the corresponding LRU queue entry to the end of the linked list. When necessary, we evict from the head of the linked list.

The current implementation requires a call to:
```
list.remove(index)
new_index = list.insert_last(key)
```
This requires a mutable reference to the entry in the `HashMap` which holds the index in the linked list.

This new method, `move_to_last(index)` updates the linked list such that the entry at `index` is now the last entry in the linked list. The index of the entry remains the same.