### PR TITLE
Fix size bug and add test for it

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -954,11 +954,10 @@ impl<T> IndexList<T> {
     }
     #[inline]
     fn remove_elem_at_index(&mut self, this: ListIndex) -> Option<T> {
-        this.get()
-            .and_then(|at| {
-                self.size -= 1;
-                self.elems[at].take()
-            })
+        let at = this.get()?;
+        let removed = self.elems[at].take()?;
+        self.size -= 1;
+        Some(removed)
     }
     fn new_node(&mut self, elem: Option<T>) -> ListIndex {
         let reuse = self.free.head;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -161,6 +161,16 @@ fn test_single_element() {
     assert_eq!(list.len(), 0);
 }
 #[test]
+fn test_remove_element_twice() {
+    let mut list = IndexList::<u64>::new();
+    let index = list.insert_first(0);
+    let removed1 = list.remove(index);
+    assert_eq!(removed1, Some(0));
+    let removed2 = list.remove(index);
+    assert_eq!(removed2, None);
+    assert_eq!(list.len(), 0);
+}
+#[test]
 fn insert_remove_variants() {
     let count = 256;
     let mut rng = rand::thread_rng();


### PR DESCRIPTION
When `list.remove` fails, it decrements the size anyway. This can potentially cause an underflow and other bugs as well.

This PR makes it so size is only decremented in the event an element is present