### PR TITLE
Fix iterator bugs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -704,6 +704,7 @@ impl<T> IndexList<T> {
             list: self,
             start: self.first_index(),
             end: self.last_index(),
+            len: self.len(),
         }
     }
     /// Create a draining iterator over all the elements.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -702,8 +702,8 @@ impl<T> IndexList<T> {
     pub fn iter(&self) -> ListIter<T> {
         ListIter {
             list: self,
-            next: self.first_index(),
-            prev: self.last_index(),
+            start: self.first_index(),
+            end: self.last_index(),
         }
     }
     /// Create a draining iterator over all the elements.

--- a/src/listdrainiter.rs
+++ b/src/listdrainiter.rs
@@ -5,6 +5,7 @@
  */
 //! The definition of the ListDrainIter type
 use std::iter::{DoubleEndedIterator, FusedIterator};
+
 use crate::{listiter::ListIter, IndexList};
 
 /// A consuming interator that will remove elements from the list as it is
@@ -38,5 +39,11 @@ impl<'a, T> IntoIterator for &'a IndexList<T> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
+    }
+}
+
+impl<T> Drop for ListDrainIter<'_, T> {
+    fn drop(&mut self) {
+        self.0.clear();
     }
 }

--- a/src/listdrainiter.rs
+++ b/src/listdrainiter.rs
@@ -33,6 +33,8 @@ impl<T> DoubleEndedIterator for ListDrainIter<'_, T> {
 
 impl<T> FusedIterator for ListDrainIter<'_, T> {}
 
+impl<T> ExactSizeIterator for ListDrainIter<'_, T> {}
+
 impl<'a, T> IntoIterator for &'a IndexList<T> {
     type Item = &'a T;
     type IntoIter = ListIter<'a, T>;

--- a/src/listiter.rs
+++ b/src/listiter.rs
@@ -5,6 +5,7 @@
  */
 //! The defintions of the ListIter type
 use std::iter::{DoubleEndedIterator, FusedIterator};
+
 use crate::{listindex::ListIndex, IndexList};
 
 /// A double-ended iterator over all the elements in the list. It is fused and
@@ -13,28 +14,47 @@ pub struct ListIter<'a, T> {
     pub(crate) list: &'a IndexList<T>,
     pub(crate) start: ListIndex,
     pub(crate) end: ListIndex,
+    pub(crate) len: usize,
+}
+
+impl<T> ListIter<'_, T> {
+    #[inline]
+    fn set_empty(&mut self) {
+        self.start = ListIndex::new();
+        self.end = ListIndex::new();
+        self.len = 0;
+    }
 }
 
 impl<'a, T> Iterator for ListIter<'a, T> {
     type Item = &'a T;
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        let item = self.list.get(self.start);
-        self.start = self.list.next_index(self.start);
-        item
+        let item = self.list.get(self.start)?;
+        if self.start == self.end {
+            self.set_empty()
+        } else {
+            self.start = self.list.next_index(self.start);
+            self.len -= 1;
+        }
+        Some(item)
     }
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let my_len = self.list.len();
-        (my_len, Some(my_len))
+        (self.len, Some(self.len))
     }
 }
 impl<T> FusedIterator for ListIter<'_, T> {}
 
 impl<T> DoubleEndedIterator for ListIter<'_, T> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        let item = self.list.get(self.end);
-        self.end = self.list.prev_index(self.end);
-        item
+        let item = self.list.get(self.end)?;
+        if self.start == self.end {
+            self.set_empty()
+        } else {
+            self.end = self.list.prev_index(self.end);
+            self.len -= 1;
+        }
+        Some(item)
     }
 }

--- a/src/listiter.rs
+++ b/src/listiter.rs
@@ -45,6 +45,7 @@ impl<'a, T> Iterator for ListIter<'a, T> {
     }
 }
 impl<T> FusedIterator for ListIter<'_, T> {}
+impl<T> ExactSizeIterator for ListIter<'_, T> {}
 
 impl<T> DoubleEndedIterator for ListIter<'_, T> {
     fn next_back(&mut self) -> Option<Self::Item> {

--- a/src/listiter.rs
+++ b/src/listiter.rs
@@ -11,16 +11,16 @@ use crate::{listindex::ListIndex, IndexList};
 /// can be reversed.
 pub struct ListIter<'a, T> {
     pub(crate) list: &'a IndexList<T>,
-    pub(crate) next: ListIndex,
-    pub(crate) prev: ListIndex,
+    pub(crate) start: ListIndex,
+    pub(crate) end: ListIndex,
 }
 
 impl<'a, T> Iterator for ListIter<'a, T> {
     type Item = &'a T;
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        let item = self.list.get(self.next);
-        self.next = self.list.next_index(self.next);
+        let item = self.list.get(self.start);
+        self.start = self.list.next_index(self.start);
         item
     }
     #[inline]
@@ -33,8 +33,8 @@ impl<T> FusedIterator for ListIter<'_, T> {}
 
 impl<T> DoubleEndedIterator for ListIter<'_, T> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        let item = self.list.get(self.prev);
-        self.prev = self.list.prev_index(self.prev);
+        let item = self.list.get(self.end);
+        self.end = self.list.prev_index(self.end);
         item
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -190,6 +190,14 @@ fn test_iterator_hint_correct_after_next() {
     assert_eq!(iter.size_hint(), (2, Some(2)));
 }
 #[test]
+fn test_inexhausted_drain_clears_list() {
+    let mut list = IndexList::<u64>::from_iter([1, 2, 3]);
+    let mut drain = list.drain_iter();
+    assert_eq!(drain.next(), Some(1));
+    drop(drain);
+    assert_eq!(list.len(), 0);
+}
+#[test]
 fn insert_remove_variants() {
     let count = 256;
     let mut rng = rand::thread_rng();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -3,10 +3,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-use index_list::{IndexList, ListIndex};
-use std::mem::size_of;
 use std::collections::HashSet;
-use rand::{Rng, seq::SliceRandom};
+use std::mem::size_of;
+
+use index_list::{IndexList, ListIndex};
+use rand::{seq::SliceRandom, Rng};
 
 fn debug_print_indexes(list: &IndexList<u64>) {
     let mut index = list.first_index();
@@ -187,34 +188,33 @@ fn insert_remove_variants() {
                     let ndx = list.insert_first(num);
                     println!("index {} first", ndx);
                     indexes.push(get_raw_index(&ndx));
-                },
+                }
                 1 => {
                     let that = ListIndex::from(indexes[rng.gen_range(0..c)] - 1);
                     print!("before {} ", that);
                     let ndx = list.insert_before(that, num);
                     println!("index {}", ndx);
                     indexes.push(get_raw_index(&ndx));
-                },
+                }
                 2 => {
                     let that = ListIndex::from(indexes[rng.gen_range(0..c)] - 1);
                     print!("after {} ", that);
                     let ndx = list.insert_after(that, num);
                     println!("index {} ", ndx);
                     indexes.push(get_raw_index(&ndx));
-                },
+                }
                 _ => {
                     let ndx = list.insert_last(num);
                     println!("index {} last", ndx);
                     indexes.push(get_raw_index(&ndx));
-                },
+                }
             }
             print!("IndexList: ");
             debug_print_indexes(&list);
         }
         assert_eq!(list.len(), count);
         for c in (1..=count).rev() {
-            let ndx = ListIndex::from(
-                indexes.swap_remove(rng.gen_range(0..c as usize)) - 1);
+            let ndx = ListIndex::from(indexes.swap_remove(rng.gen_range(0..c as usize)) - 1);
             println!("IndexList - remove {}", ndx);
             let num = list.remove(ndx).unwrap();
             //println!("IndexList: {}", list.to_debug_string());

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -172,6 +172,24 @@ fn test_remove_element_twice() {
     assert_eq!(list.len(), 0);
 }
 #[test]
+fn singleton_element_occurs_on_front_xor_back() {
+    let list = IndexList::<u64>::from_iter([1]);
+    let mut iter = list.iter();
+    assert_eq!(iter.next(), Some(&1));
+    assert_eq!(iter.next_back(), None);
+    let mut iter = list.iter();
+    assert_eq!(iter.next_back(), Some(&1));
+    assert_eq!(iter.next(), None);
+}
+#[test]
+fn test_iterator_hint_correct_after_next() {
+    let list = IndexList::<u64>::from_iter([1, 2, 3]);
+    let mut iter = list.iter();
+    assert_eq!(iter.size_hint(), (3, Some(3)));
+    assert_eq!(iter.next(), Some(&1));
+    assert_eq!(iter.size_hint(), (2, Some(2)));
+}
+#[test]
 fn insert_remove_variants() {
     let count = 256;
     let mut rng = rand::thread_rng();


### PR DESCRIPTION
Fix `next` and `next_back` potentially each returning the same element.
Also, make sure that the `size_hint` returns the number of elements _remaining_ rather than the total number of elements.
`drain_iter` should always drain the list, even if it's not fully consumed (since there aren't memory safety issues in play, we won't worry about the `mem::forget` case, the way `Vec::drain` does)