### PR TITLE
Add iter_mut guarded behind a feature flag.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ readme = "README.md"
 criterion = "0.5"
 rand = "0.8"
 
+[features]
+# `iter_mut` is guarded behind a feature flag because the implementation uses unsafety
+iter_mut = []
+
 [[bench]]
 name = "indexlist-benchmark"
 path = "benches/benchmark.rs"

--- a/src/listiter.rs
+++ b/src/listiter.rs
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-//! The defintions of the ListIter type
+//! The definitions of the ListIter type
 use std::iter::{DoubleEndedIterator, FusedIterator};
 
 use crate::{listindex::ListIndex, IndexList};

--- a/src/listitermut.rs
+++ b/src/listitermut.rs
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-//! The defintions of the ListIterMut type
+//! The definitions of the ListIterMut type
 use std::iter::{DoubleEndedIterator, FusedIterator};
 
 use crate::listindex::ListIndex;

--- a/src/listitermut.rs
+++ b/src/listitermut.rs
@@ -1,0 +1,83 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+//! The defintions of the ListIterMut type
+use std::iter::{DoubleEndedIterator, FusedIterator};
+
+use crate::listindex::ListIndex;
+use crate::listnode::ListNode;
+
+/// A double-ended mutating iterator over all the elements in the list. It is fused and
+/// can be reversed.
+pub struct ListIterMut<'a, T> {
+    // This field can't be a slice without violating aliasing rules since we're going to be
+    // mutably borrowing elements from it.
+    pub(crate) elems: *mut Option<T>,
+    pub(crate) nodes: &'a [ListNode],
+    pub(crate) start: ListIndex,
+    pub(crate) end: ListIndex,
+    pub(crate) len: usize,
+}
+
+impl<T> ListIterMut<'_, T> {
+    #[inline]
+    fn set_empty(&mut self) {
+        self.start = ListIndex::new();
+        self.end = ListIndex::new();
+        self.len = 0;
+    }
+}
+
+impl<'a, T: 'a> Iterator for ListIterMut<'a, T> {
+    type Item = &'a mut T;
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let idx = self.start.get()?;
+        // SAFETY: Indices only ever refer to entries in `elems`, so `elems` is a witness that this
+        // add operation won't overflow
+        let elem_ptr = unsafe { self.elems.add(idx) };
+        if self.start == self.end {
+            self.set_empty();
+        } else {
+            self.start = self.nodes[idx].next;
+            self.len -= 1;
+        }
+        // SAFETY: We rely on the fact that the public API to `IndexList` does not provide a way
+        // to construct a `nodes` slice which contains cycles or duplicate
+        // indices to ensure that each element is visited at most once (this invariant is thus a
+        // prerequisite of memory safety). This means that between
+        // all `next` and `next_back` calls, we only return at most one unshared reference to each
+        // element.
+        Some(unsafe { &mut *elem_ptr }.as_mut().unwrap())
+    }
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len, Some(self.len))
+    }
+}
+impl<'a, T: 'a> FusedIterator for ListIterMut<'a, T> {}
+impl<'a, T: 'a> ExactSizeIterator for ListIterMut<'a, T> {}
+
+impl<'a, T: 'a> DoubleEndedIterator for ListIterMut<'a, T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        let idx = self.end.get()?;
+        // SAFETY: Indices only ever refer to entries in `elems`, so `elems` is a witness that this
+        // add operation won't overflow
+        let elem_ptr = unsafe { self.elems.add(idx) };
+        if self.start == self.end {
+            self.set_empty();
+        } else {
+            self.end = self.nodes[idx].prev;
+            self.len -= 1;
+        }
+        // SAFETY: We rely on the fact that the public API to `IndexList` does not provide a way
+        // to construct a `nodes` slice which contains cycles or duplicate
+        // indices to ensure that each element is visited at most once (this invariant is thus a
+        // prerequisite of memory safety). This means that between
+        // all `next` and `next_back` calls, we only return at most one unshared reference to each
+        // element.
+        Some(unsafe { &mut *elem_ptr }.as_mut().unwrap())
+    }
+}

--- a/tests/iter_mut.rs
+++ b/tests/iter_mut.rs
@@ -1,0 +1,43 @@
+#![cfg(feature = "iter_mut")]
+/*
+ * Tests for the mutating iterator (iter_mut) feature.
+ */
+use index_list::IndexList;
+
+#[test]
+fn iter_mut_basic_mutation_and_order() {
+    let mut list = IndexList::from(&mut vec![1, 2, 3, 4]);
+    {
+        let mut it = list.iter_mut();
+        assert_eq!(it.size_hint(), (4, Some(4)));
+        *it.next().unwrap() *= 10; // 1 -> 10
+        *it.next_back().unwrap() *= 10; // 4 -> 40
+        *it.next().unwrap() *= 10; // 2 -> 20
+        assert_eq!(it.size_hint(), (1, Some(1)));
+        *it.next_back().unwrap() *= 10; // 3 -> 30
+        assert_eq!(it.next(), None);
+        assert_eq!(it.next_back(), None);
+    }
+    // After iterator is dropped we can drain to verify final order/content
+    let collected: Vec<_> = list.drain_iter().collect();
+    assert_eq!(collected, vec![10, 20, 30, 40]);
+}
+
+#[test]
+fn iter_mut_empty() {
+    let mut list = IndexList::<u32>::new();
+    let mut it = list.iter_mut();
+    assert_eq!(it.next(), None);
+    assert_eq!(it.next_back(), None);
+    assert_eq!(it.size_hint(), (0, Some(0)));
+}
+
+#[test]
+fn iter_mut_fused() {
+    let mut list = IndexList::from(&mut vec![5, 6]);
+    let mut it = list.iter_mut();
+    assert!(it.next().is_some());
+    assert!(it.next().is_some());
+    assert_eq!(it.next(), None); // exhausted
+    assert_eq!(it.next_back(), None); // still None after exhaustion (fused)
+}


### PR DESCRIPTION
`iter_mut` necessarily requires unsafety to implement, but it's very useful to have. We can guard it behind a feature flag and conditionally forbid unsafe code only when that feature flag is disabled.

FYI `dspyz-matician` is my work account. This is my personal account